### PR TITLE
fix: sanitize print rendering to prevent stored XSS

### DIFF
--- a/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/ot/ot-booking-list/ot-booking-details/consent-form/consent-form.component.ts
+++ b/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/ot/ot-booking-list/ot-booking-details/consent-form/consent-form.component.ts
@@ -1,10 +1,10 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import * as moment from "moment";
 import { ClinicalTemplate_DTO } from '../../../../clinical-settings/shared/dto/get-clinical-template.dto';
 import { GetOTBookingDetails_DTO } from '../../../../ot/shared/dto/get-ot-booking-details.dto';
 import { OperationTheatreBLService } from '../../../../ot/shared/ot.bl.service';
 import { DanpheHTTPResponse } from '../../../../shared/common-models';
+import { CommonFunctions } from '../../../../shared/common.functions';
 import { MessageboxService } from '../../../../shared/messagebox/messagebox.service';
 import { ENUM_DanpheHTTPResponses, ENUM_MessageBox_Status } from '../../../../shared/shared-enums';
 
@@ -21,7 +21,7 @@ export class ConsentFormComponent implements OnInit {
   ShowConsentFormPage: boolean = false;
   loading: boolean = false;
   SelectedTemplate = new ClinicalTemplate_DTO();
-  TemplateHTMLContent: SafeHtml = '';
+  TemplateHTMLContent: string = '';
   ShowConsent: boolean = false;
   @ViewChild('consentForm') consentForm: ElementRef;
   IsTemplateSelected: boolean = false;
@@ -29,7 +29,6 @@ export class ConsentFormComponent implements OnInit {
   constructor(
     private _otBLService: OperationTheatreBLService,
     private _messageBoxService: MessageboxService,
-    private _domSanitizer: DomSanitizer,
   ) {
 
   }
@@ -75,8 +74,7 @@ export class ConsentFormComponent implements OnInit {
       if (template) {
         this.SelectedTemplate = template;
         let updatedHTMLContent = this.ReplacePlaceholders(template.TemplateHTML);
-        let sanitizedHTMLContent = this._domSanitizer.bypassSecurityTrustHtml(updatedHTMLContent);
-        this.TemplateHTMLContent = sanitizedHTMLContent;
+        this.TemplateHTMLContent = CommonFunctions.SanitizeHtmlForPrint(updatedHTMLContent);
         this.ShowConsent = true;
       }
     }
@@ -87,13 +85,13 @@ export class ConsentFormComponent implements OnInit {
 
   ReplacePlaceholders(templateHTML: string): string {
     return templateHTML
-      .replace('{{PatientName}}', this.SelectedOTBooking.PatientName)
-      .replace('{{CurrentDate}}', moment().format("YYYY-MM-DD"));
+      .replace('{{PatientName}}', CommonFunctions.HtmlEncode(this.SelectedOTBooking.PatientName))
+      .replace('{{CurrentDate}}', CommonFunctions.HtmlEncode(moment().format("YYYY-MM-DD")));
   }
 
   PrintConsentForm(): void {
     this.loading = true;
-    let printContents = this.consentForm.nativeElement.innerHTML;
+    let printContents = CommonFunctions.SanitizeHtmlForPrint(this.consentForm.nativeElement.innerHTML);
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 

--- a/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/common.functions.ts
+++ b/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/common.functions.ts
@@ -242,6 +242,56 @@ export class CommonFunctions {
     return retString;
   }
 
+  static HtmlEncode(input: any): string {
+    if (input === null || input === undefined) {
+      return "";
+    }
+
+    return input.toString()
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  static SanitizeHtmlForPrint(inputHtml: any): string {
+    if (inputHtml === null || inputHtml === undefined) {
+      return "";
+    }
+
+    let parser = new DOMParser();
+    let parsedDoc = parser.parseFromString(inputHtml.toString(), "text/html");
+    let blockedElements = parsedDoc.querySelectorAll("script, iframe, object, embed, base, form, input, button, textarea, select, meta[http-equiv='refresh']");
+
+    for (let index = blockedElements.length - 1; index >= 0; index--) {
+      blockedElements[index].parentNode.removeChild(blockedElements[index]);
+    }
+
+    let allElements = parsedDoc.body.getElementsByTagName("*");
+    for (let elementIndex = 0; elementIndex < allElements.length; elementIndex++) {
+      let element = allElements[elementIndex];
+      let attributes = Array.prototype.slice.call(element.attributes);
+
+      attributes.forEach((attr: Attr) => {
+        let attrName = attr.name.toLowerCase();
+        let attrValue = attr.value ? attr.value.trim().toLowerCase() : "";
+
+        if (attrName.indexOf("on") === 0 || attrName === "srcdoc" || attrName === "formaction") {
+          element.removeAttribute(attr.name);
+        }
+        else if ((attrName === "href" || attrName === "src" || attrName === "xlink:href") && attrValue.indexOf("javascript:") === 0) {
+          element.removeAttribute(attr.name);
+        }
+        else if (attrName === "style" && (attrValue.indexOf("expression(") >= 0 || attrValue.indexOf("javascript:") >= 0)) {
+          element.removeAttribute(attr.name);
+        }
+      });
+    }
+
+    return parsedDoc.body.innerHTML;
+  }
+
   static GetUniqueItemsFromArray(inputArr: any[]) {
     //var items = [4, 5, 4, 6, 3, 4, 5, 2, 23, 1, 4, 4, 4]
     //below code works only for es6, we might need other solution.

--- a/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/danphe-grid/danphe-grid.component.ts
+++ b/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/danphe-grid/danphe-grid.component.ts
@@ -675,7 +675,7 @@ export class DanpheGridComponent implements OnInit, AfterViewInit {
         printContents = (this.paramData.ShowFooter) ? printContents + this.footerContent : printContents;
       }
       documentContent +=
-        '<body onload="window.print()">' + printContents + "</body></html>";
+        '<body onload="window.print()">' + CommonFunctions.SanitizeHtmlForPrint(printContents) + "</body></html>";
       popupWinindow.document.write(documentContent);
       popupWinindow.document.close();
     }
@@ -696,7 +696,7 @@ export class DanpheGridComponent implements OnInit, AfterViewInit {
       var th = document.createElement("th"); // TABLE HEADER.
       th.setAttribute("style", "font-weight:bold; border:1px solid black;");
       th.style.backgroundColor = "#ababad";
-      th.innerHTML = CommonFunctions.GetKeyName(newCol[i], gridColList); //newCol[i];
+      th.textContent = CommonFunctions.GetKeyName(newCol[i], gridColList); //newCol[i];
       tr.appendChild(th);
     }
 
@@ -706,7 +706,7 @@ export class DanpheGridComponent implements OnInit, AfterViewInit {
       for (var j = 0; j < newCol.length; j++) {
         var tabCell = tr.insertCell(-1);
         tabCell.setAttribute("style", "border:1px solid black;");
-        tabCell.innerHTML = data[i][newCol[j]];
+        tabCell.textContent = data[i][newCol[j]] === null || data[i][newCol[j]] === undefined ? "" : data[i][newCol[j]].toString();
       }
     }
     // FINALLY ADD THE NEWLY CREATED TABLE WITH JSON DATA TO A CONTAINER.
@@ -1813,7 +1813,7 @@ export class DanpheGridComponent implements OnInit, AfterViewInit {
     this.changeDetector.detectChanges();
     printContents = (this.footerContent) ? printContents + this.footerContent : printContents;
     documentContent +=
-      '<body onload="window.print()">' + printContents + "</body></html>";
+      '<body onload="window.print()">' + CommonFunctions.SanitizeHtmlForPrint(printContents) + "</body></html>";
     popupWinindow.document.write(documentContent);
     popupWinindow.document.close();
   }
@@ -1992,7 +1992,7 @@ export class DanpheGridComponent implements OnInit, AfterViewInit {
     this.changeDetector.detectChanges();
     printContents = (this.footerContent) ? printContents + this.footerContent : printContents;
     documentContent +=
-      '<body onload="window.print()">' + printContents + "</body></html>";
+      '<body onload="window.print()">' + CommonFunctions.SanitizeHtmlForPrint(printContents) + "</body></html>";
     popupWinindow.document.write(documentContent);
     popupWinindow.document.close();
   }

--- a/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/print-service/print-new.component.ts
+++ b/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/print-service/print-new.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonFunctions } from '../common.functions';
 
 @Component({
   selector: 'new-print-page',
@@ -29,7 +30,7 @@ export class DanphePrintNewComponent implements OnInit {
   }
   // backup
   print() {
-    var contents = this.printData;
+    var contents = CommonFunctions.SanitizeHtmlForPrint(this.printData);
     var iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     let documentContent = "<html><head>";

--- a/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/print-service/print.component.ts
+++ b/Code/Websites/DanpheEMR/wwwroot/DanpheApp/src/app/shared/print-service/print.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommonFunctions } from '../common.functions';
 
 @Component({
   selector: 'app-print-page',
@@ -27,7 +28,7 @@ export class DanphePrintComponent implements OnInit {
   }
 
   print() {
-    let contents = this.printData;
+    let contents = CommonFunctions.SanitizeHtmlForPrint(this.printData);
     let iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     let documentContent = "<html><head>";

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Danphe EMR is an enterprise web-based application that simplifies hospital manag
 Danphe HMIS has been consistent throughout these years and with that there are some achievements we have received.
 1. **[Recommendation letter from Kenya(Kalimoni Mission Hospital)](https://github.com/hospital-management-system-emr/HIMS-EMR-Recommendation/blob/3196c8ce3370cb6619459c13e15417afd00effba/DANPHE%20RECOMMENDATION(Kalimoni).pdf)**  
 2. **[Recommendation letter from India(SGM)](https://github.com/hospital-management-system-emr/HIMS-EMR-Recommendation/blob/3196c8ce3370cb6619459c13e15417afd00effba/recommendation%20later(SGM).pdf)**  
-
+3. **[Recommendation letter from India(Telangana)](https://github.com/hospital-management-system-emr/HIMS-EMR-Recommendation/blob/main/DanpheRecommendationTelangana.jpg)**  
 ---
 
 ## 🛠 Tech Stack  

--- a/README.md
+++ b/README.md
@@ -322,3 +322,4 @@ Reach to us through our social media platforms:
 
 ---
 [Back to top](#top)
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 <p align="center">
   ▶️ Click on the image above to have a clear walkthrough of our Hospital Management & EMR System.
   </p>
-
+<p align="center">
+  ▶️ Join our Whatsapp group . <a href="https://chat.whatsapp.com/D9ZafCPqxek79lMmjE6DhY" target="_blank">
+    Click here to join
+  </a>
+  </p>
 
  
 ## Overview  
@@ -51,6 +55,7 @@ Danphe HMIS has been consistent throughout these years and with that there are s
 - [Supported LIS Machines](#supported-lis-machines)
 - [Credits](#credits)
 - [ License](#-license)
+- [ Enterprise Release Notes](#enterprise-release-notes)
 - [ Contacts](#-contacts)
 
 ---
@@ -73,9 +78,10 @@ Danphe EMR is an open-source web-based HIMS + EMR + EHR to make hospitals digiti
 
 Have a quick headstart of the Danphe EMR with some of the links listed below be sure to check them out:
 ### 🛠 Installation Guides 
-1. **[Installing Danphe App in Desktop Mode](https://www.youtube.com/watch?v=lKORZmKG0sA)**  
-2. **[Configuring Danphe inside IIS](https://www.youtube.com/watch?v=HmAAbFiPOKw)**
-3. **[License  Error](https://www.youtube.com/watch?v=FzjGJ5xm9mc)**
+-  Lesson 1 - **[Installing Danphe App in Desktop Mode](https://www.youtube.com/watch?v=lKORZmKG0sA)**  
+-  Lesson 2 - **[Configuring Danphe inside IIS](https://www.youtube.com/watch?v=HmAAbFiPOKw)** 
+ - Lesson 3 - **[License  Error](https://www.youtube.com/watch?v=FzjGJ5xm9mc)**
+-  Lab 4 and Lab 5  - **[Changing hospital logo, Name and Billing Header](https://www.youtube.com/watch?v=vK7yF90xuf4)**
 
 ---
 
@@ -117,8 +123,8 @@ Start contributing to Danphe EMR with the comprehensive [Setup Guide](https://op
 ### 🔗 Interactive Flow Diagram
 
 
-<a href="https://sam101-pic.github.io/Danphe_HMIS/Sam.html" target="_blank">
-  <img src="./Docs/Flow_diagrams/Basic_Flow.jpg" alt="Flow Diagram" />
+<a href="https://Sam101-pic.github.io/danphe-readme/Flow_diagrams/index.html" target="_blank">
+  <img src="./Flow_diagrams/Patient_Journey.jpg" alt="Flow Diagram" />
   </a>
 
 
@@ -296,6 +302,14 @@ Please read the following [License](https://github.com/Sam101-pic/HTML-CSS/blob/
 
 ---
 
+
+## Enterprise Release Notes
+
+This release introduces significant enhancements across multiple modules including administrative management, pharmacy operations, accounting workflows, and user experience improvements.Click on 
+[Enterprise Release Notes](https://github.com/hospital-management-system-emr/hims-emr-enterpise) for more information. Thank you!
+
+---
+
 ## 💬 Contacts
 For any further details be sure to contact us through our social links and for furthermore details be sure to mail me.
 - **Email**: Send us any of your inquries through this mail [shiv_koirala@yahoo.com](mailto:shiv_koirala@yahoo.com).
@@ -308,4 +322,3 @@ Reach to us through our social media platforms:
 
 ---
 [Back to top](#top)
-


### PR DESCRIPTION
Harden print rendering paths against stored XSS by sanitizing HTML before writing it to print iframes/popups.

Changes:
- Added shared HTML encoding and print sanitization helpers in CommonFunctions.
- Sanitized shared print component output before document.write.
- Sanitized new print component output before document.write.
- Updated danphe-grid print rendering to use textContent for grid cell/header values instead of innerHTML.
- Sanitized danphe-grid print popup content before writing it.
- Removed bypassSecurityTrustHtml from OT consent form rendering.
- Encoded OT consent form placeholder values and sanitized template/print content.

This prevents stored payloads such as script tags in fields like OT Machine Name from executing through report/grid print functionality.